### PR TITLE
Adicionando goreleaser

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,29 @@
+name: goreleaser
+
+on:
+  pull_request:
+  push:
+
+permissions:
+  contents: write
+
+jobs:
+  goreleaser:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - name: Set up Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: 1.16
+      - name: Run GoReleaser
+        uses: goreleaser/goreleaser-action@v2
+        with:
+          distribution: goreleaser
+          version: latest
+          args: release --rm-dist
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,8 +2,8 @@ name: goreleaser
 
 on:
   push:
-    tags:
-      - '*'
+    branches:
+      - main 
 
 permissions:
   contents: write

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,8 +1,9 @@
 name: goreleaser
 
 on:
-  pull_request:
   push:
+  tags:
+    - '*'
 
 permissions:
   contents: write

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,8 +2,8 @@ name: goreleaser
 
 on:
   push:
-  tags:
-    - '*'
+    tags:
+      - '*'
 
 permissions:
   contents: write

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 data/
+dist/

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,0 +1,19 @@
+before:
+  hooks:
+    - go mod tidy
+builds:
+  - env:
+      - CGO_ENABLED=0
+    goos:
+      - linux
+      - windows
+      - darwin
+archives:
+  - replacements:
+      darwin: Darwin
+      linux: Linux
+      windows: Windows
+      386: i386
+      amd64: x86_64
+changelog:
+  sort: asc


### PR DESCRIPTION
Este commit adiciona um suporte inicial ao [goreleaser](https://goreleaser.com/), que toma conta dos releases a cada push de tags. 
Caso deseje, ele também tem suporte ao docker, mas como não sabia se a imagem está sendo enviada para algum registry, ainda não fiz as alterações no arquivo de release para fazer o push das imagens.

Um [`GITHUB_TOKEN`](https://docs.github.com/en/actions/reference/authentication-in-a-workflow) vai ter que ser providenciado para que a action funcione corretamente